### PR TITLE
Switch transaction list to accept list (not Data State)

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -3,3 +3,10 @@
 Multiplatform kotlin sources for you-need-a-splitter.
 
 For now, this is a Kotlin/JS web client.
+
+Make sure to run it with an access token in the environment.
+
+```sh
+export YNAB_ACCESS_TOKEN=your_access_token
+./gradlew run
+```

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -1,7 +1,6 @@
 package com.dchaley.ynas
 
 import com.dchaley.ynas.util.DataState
-import com.dchaley.ynas.util.replaceAll
 import io.kvision.*
 import io.kvision.core.AlignItems
 import io.kvision.html.div
@@ -14,87 +13,8 @@ import io.kvision.utils.auto
 import io.kvision.utils.perc
 import io.kvision.utils.px
 import js.core.structuredClone
-import ynab.BudgetSummary
 import ynab.TransactionDetail
 import ynab.api
-
-class DataModel {
-    private val budgetsObservable = ObservableValue<DataState<ObservableList<BudgetSummary>>>(DataState.Unloaded)
-    private val selectedBudgetObservable = ObservableValue<BudgetSummary?>(null)
-    private val transactionsStoreObservable = ObservableValue<DataState<MutableMap<String, TransactionDetail>>>(DataState.Unloaded)
-    private val displayedTransactionsObservable = ObservableValue<DataState<ObservableList<TransactionDetail>>>(DataState.Unloaded)
-
-    var budgets: DataState<ObservableList<BudgetSummary>>
-        get() = budgetsObservable.value
-        set(value) { budgetsObservable.value = value }
-
-    var selectedBudget: BudgetSummary?
-        get() = selectedBudgetObservable.value
-        set(value) { selectedBudgetObservable.value = value }
-
-    var transactionsStore: DataState<MutableMap<String, TransactionDetail>>
-        get() = transactionsStoreObservable.value
-        set(value) {
-            transactionsStoreObservable.value = value
-            updateDisplayedTxns()
-        }
-
-    var displayedTransactions: DataState<ObservableList<TransactionDetail>>
-        get() = displayedTransactionsObservable.value
-        set(value) { displayedTransactionsObservable.value = value }
-
-    fun updateDisplayedTxns() {
-        when (transactionsStore) {
-            is DataState.Unloaded -> {
-                displayedTransactions = DataState.Unloaded
-            }
-
-            is DataState.Loading -> {
-                displayedTransactions = DataState.Loading
-            }
-
-            is DataState.Loaded -> {
-                val txns = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data.values
-                // this could sort by anything… but for now, just sort by date
-                val sorted = txns.sortedBy { it.date }
-
-                // We don't want to trigger a re-render if the list is already loaded.
-                // Setting the value outright (vs replacing contents) triggers a higher-level re-render.
-                if (displayedTransactions !is DataState.Loaded<*>) {
-                    displayedTransactions = DataState.Loaded(observableListOf(*sorted.toTypedArray()))
-                }
-                else {
-                    val existingList = (displayedTransactions as DataState.Loaded<ObservableList<TransactionDetail>>).data
-                    (existingList as ObservableListWrapper).replaceAll(sorted)
-                }
-            }
-        }
-    }
-
-    fun updateTransaction(original: TransactionDetail, updated: TransactionDetail) {
-        // replace the old object with the updated one
-        val storedTransactions = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data
-        storedTransactions[original.id] = updated
-
-        updateDisplayedTxns()
-    }
-
-    fun observeBudgets(): ObservableValue<DataState<ObservableList<BudgetSummary>>> {
-        return budgetsObservable
-    }
-
-    fun observeSelectedBudget(): ObservableValue<BudgetSummary?> {
-        return selectedBudgetObservable
-    }
-
-    fun observeTransactionsStore(): ObservableValue<DataState<MutableMap<String, TransactionDetail>>> {
-        return transactionsStoreObservable
-    }
-
-    fun observeDisplayedTransactions(): ObservableValue<DataState<ObservableList<TransactionDetail>>> {
-        return displayedTransactionsObservable
-    }
-}
 
 class App : Application() {
     init {
@@ -127,6 +47,11 @@ class App : Application() {
             }
             val copied = structuredClone(transactionDetail)
             copied.payee_name += " (approved)"
+
+            // TODO: implement transaction approval.
+            // Issue the call to ynab budget.
+            // When it comes back successfully, insert it into the data model.
+            // In the meantime, give it a spinny!
 
             dataModel.updateTransaction(transactionDetail, copied)
         }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -3,12 +3,15 @@ package com.dchaley.ynas
 import com.dchaley.ynas.util.DataState
 import io.kvision.*
 import io.kvision.core.AlignItems
+import io.kvision.core.CssSize
+import io.kvision.core.UNIT
 import io.kvision.html.*
 import io.kvision.panel.root
 import io.kvision.panel.vPanel
 import io.kvision.state.bind
 import io.kvision.state.observableListOf
 import io.kvision.utils.auto
+import io.kvision.utils.em
 import io.kvision.utils.perc
 import io.kvision.utils.px
 import js.core.structuredClone
@@ -75,7 +78,7 @@ class App : Application() {
                             div().bind(dataModel.observeBudgets()) { state ->
                                 budgetSelector(state) { newBudget ->
                                     dataModel.selectedBudget = newBudget
-                                    dataModel.displayedTransactions = DataState.Loading
+                                    dataModel.transactionsStore = DataState.Loading
                                     ynab.transactions.getTransactions(newBudget.id, type="unapproved").then { response ->
                                         val pairs = response.data.transactions.map { it.id to it }.toTypedArray()
                                         dataModel.transactionsStore = DataState.Loaded(mutableMapOf(*pairs))
@@ -87,24 +90,24 @@ class App : Application() {
 
                     div().bind(dataModel.observeTransactionsStore()) { state ->
                         borderedContainer {
+                          padding = 2.em
+                          vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
+                            padding = 2.em
                             when (state) {
-                                is DataState.Unloaded -> {
-                                    vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
-                                        h4("no transactions loaded!")
-                                    }
-                                }
+                              is DataState.Unloaded -> {
+                                h4("no transactions loaded!")
+                              }
 
-                                is DataState.Loading -> {
-                                    vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
-                                        icon("fas fa-spinner fa-xl fa-spin")
-                                        h4("loading transactions…")
-                                    }
-                                }
+                              is DataState.Loading -> {
+                                icon("fas fa-spinner fa-xl fa-spin")
+                                h4("loading transactions…")
+                              }
 
-                                is DataState.Loaded -> {
-                                    transactionsList(dataModel.displayedTransactions, onApprove = ::onApprove)
-                                }
+                              is DataState.Loaded -> {
+                                transactionsList(dataModel.displayedTransactions, onApprove = ::onApprove)
+                              }
                             }
+                          }
                         }
                     }
                 }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -3,8 +3,6 @@ package com.dchaley.ynas
 import com.dchaley.ynas.util.DataState
 import io.kvision.*
 import io.kvision.core.AlignItems
-import io.kvision.core.CssSize
-import io.kvision.core.UNIT
 import io.kvision.html.*
 import io.kvision.panel.root
 import io.kvision.panel.vPanel
@@ -19,108 +17,107 @@ import ynab.TransactionDetail
 import ynab.api
 
 class App : Application() {
-    init {
-        require("@fortawesome/fontawesome-free/js/brands.js")
-        require("@fortawesome/fontawesome-free/js/solid.js")
-        require("@fortawesome/fontawesome-free/js/fontawesome.js")
+  init {
+    require("@fortawesome/fontawesome-free/js/brands.js")
+    require("@fortawesome/fontawesome-free/js/solid.js")
+    require("@fortawesome/fontawesome-free/js/fontawesome.js")
+  }
+
+
+  override fun start() {
+    // Read the variable YNAB_ACCESS_TOKEN from the environment (see config.js in webpack.config.d)
+    val env = js("PROCESS_ENV")
+    val accessToken = env.YNAB_ACCESS_TOKEN as String
+
+    // The YNAB API client.
+    val ynab = api(accessToken)
+
+    val dataModel = DataModel()
+
+    ynab.budgets.getBudgets().then { response ->
+      dataModel.budgets = DataState.Loaded(observableListOf(*response.data.budgets))
     }
 
+    dataModel.observeTransactionsStore().subscribe { _ ->
+    }
 
-    override fun start() {
-        // Read the variable YNAB_ACCESS_TOKEN from the environment (see config.js in webpack.config.d)
-        val env = js("PROCESS_ENV")
-        val accessToken = env.YNAB_ACCESS_TOKEN as String
+    fun onApprove(transactionDetail: TransactionDetail) {
+      if (dataModel.displayedTransactions !is DataState.Loaded<*>) {
+        console.log("onApprove called when transactions not loaded")
+        return
+      }
+      val copied = structuredClone(transactionDetail)
+      copied.payee_name += " (approved)"
 
-        // The YNAB API client.
-        val ynab = api(accessToken)
+      // TODO: implement transaction approval.
+      // Issue the call to ynab budget.
+      // When it comes back successfully, insert it into the data model.
+      // In the meantime, give it a spinny!
 
-        val dataModel = DataModel()
+      dataModel.updateTransaction(transactionDetail, copied)
+    }
 
-        ynab.budgets.getBudgets().then { response ->
-            dataModel.budgets = DataState.Loaded(observableListOf(*response.data.budgets))
-        }
+    root("kvapp") {
+      vPanel(alignItems = AlignItems.STRETCH, useWrappers = true) {
+        margin = 15.px
+        maxWidth = 75.perc
+        marginLeft = auto
+        marginRight = auto
+        vPanel(spacing = 5, alignItems = AlignItems.STRETCH, useWrappers = true) {
+          header {
+            h1("You Need a Splitter!")
+          }
 
-        dataModel.observeTransactionsStore().subscribe { _ ->
-        }
-
-        fun onApprove(transactionDetail: TransactionDetail) {
-            if (dataModel.displayedTransactions !is DataState.Loaded<*>) {
-                console.log("onApprove called when transactions not loaded")
-                return
-            }
-            val copied = structuredClone(transactionDetail)
-            copied.payee_name += " (approved)"
-
-            // TODO: implement transaction approval.
-            // Issue the call to ynab budget.
-            // When it comes back successfully, insert it into the data model.
-            // In the meantime, give it a spinny!
-
-            dataModel.updateTransaction(transactionDetail, copied)
-        }
-
-        root("kvapp") {
-            vPanel(alignItems = AlignItems.STRETCH, useWrappers = true) {
-                margin = 15.px
-                maxWidth = 75.perc
-                marginLeft = auto
-                marginRight = auto
-                vPanel(spacing = 5, alignItems = AlignItems.STRETCH, useWrappers = true) {
-                    header {
-                        h1("You Need a Splitter!")
-                    }
-
-                    div().bind(dataModel.observeSelectedBudget()) { budget ->
-                        if (budget != null) {
-                            div("Selected budget: ${budget.name}")
-                        }
-                        else {
-                            div().bind(dataModel.observeBudgets()) { state ->
-                                budgetSelector(state) { newBudget ->
-                                    dataModel.selectedBudget = newBudget
-                                    dataModel.transactionsStore = DataState.Loading
-                                    ynab.transactions.getTransactions(newBudget.id, type="unapproved").then { response ->
-                                        val pairs = response.data.transactions.map { it.id to it }.toTypedArray()
-                                        dataModel.transactionsStore = DataState.Loaded(mutableMapOf(*pairs))
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    div().bind(dataModel.observeTransactionsStore()) { state ->
-                        borderedContainer {
-                          padding = 2.em
-                          vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
-                            padding = 2.em
-                            when (state) {
-                              is DataState.Unloaded -> {
-                                h4("no transactions loaded!")
-                              }
-
-                              is DataState.Loading -> {
-                                icon("fas fa-spinner fa-xl fa-spin")
-                                h4("loading transactions…")
-                              }
-
-                              is DataState.Loaded -> {
-                                transactionsList(dataModel.displayedTransactions, onApprove = ::onApprove)
-                              }
-                            }
-                          }
-                        }
-                    }
+          div().bind(dataModel.observeSelectedBudget()) { budget ->
+            if (budget != null) {
+              div("Selected budget: ${budget.name}")
+            } else {
+              div().bind(dataModel.observeBudgets()) { state ->
+                budgetSelector(state) { newBudget ->
+                  dataModel.selectedBudget = newBudget
+                  dataModel.transactionsStore = DataState.Loading
+                  ynab.transactions.getTransactions(newBudget.id, type = "unapproved").then { response ->
+                    val pairs = response.data.transactions.map { it.id to it }.toTypedArray()
+                    dataModel.transactionsStore = DataState.Loaded(mutableMapOf(*pairs))
+                  }
                 }
+              }
             }
+          }
+
+          div().bind(dataModel.observeTransactionsStore()) { state ->
+            borderedContainer {
+              padding = 2.em
+              vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
+                padding = 2.em
+                when (state) {
+                  is DataState.Unloaded -> {
+                    h4("no transactions loaded!")
+                  }
+
+                  is DataState.Loading -> {
+                    icon("fas fa-spinner fa-xl fa-spin")
+                    h4("loading transactions…")
+                  }
+
+                  is DataState.Loaded -> {
+                    transactionsList(dataModel.displayedTransactions, onApprove = ::onApprove)
+                  }
+                }
+              }
+            }
+          }
         }
+      }
     }
+  }
 }
 
 fun main() {
-    startApplication(
-        ::App,
-        module.hot,
-        BootstrapModule,
-        CoreModule
-    )
+  startApplication(
+    ::App,
+    module.hot,
+    BootstrapModule,
+    CoreModule
+  )
 }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -3,12 +3,11 @@ package com.dchaley.ynas
 import com.dchaley.ynas.util.DataState
 import io.kvision.*
 import io.kvision.core.AlignItems
-import io.kvision.html.div
-import io.kvision.html.h1
-import io.kvision.html.header
+import io.kvision.html.*
 import io.kvision.panel.root
 import io.kvision.panel.vPanel
-import io.kvision.state.*
+import io.kvision.state.bind
+import io.kvision.state.observableListOf
 import io.kvision.utils.auto
 import io.kvision.utils.perc
 import io.kvision.utils.px
@@ -29,6 +28,7 @@ class App : Application() {
         val env = js("PROCESS_ENV")
         val accessToken = env.YNAB_ACCESS_TOKEN as String
 
+        // The YNAB API client.
         val ynab = api(accessToken)
 
         val dataModel = DataModel()
@@ -85,8 +85,27 @@ class App : Application() {
                         }
                     }
 
-                    div().bind(dataModel.observeDisplayedTransactions()) { state ->
-                        borderedContainer { transactionsList(state, onApprove = ::onApprove) }
+                    div().bind(dataModel.observeTransactionsStore()) { state ->
+                        borderedContainer {
+                            when (state) {
+                                is DataState.Unloaded -> {
+                                    vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
+                                        h4("no transactions loaded!")
+                                    }
+                                }
+
+                                is DataState.Loading -> {
+                                    vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
+                                        icon("fas fa-spinner fa-xl fa-spin")
+                                        h4("loading transactions…")
+                                    }
+                                }
+
+                                is DataState.Loaded -> {
+                                    transactionsList(dataModel.displayedTransactions, onApprove = ::onApprove)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
@@ -11,7 +11,10 @@ import io.kvision.state.ObservableList
 import io.kvision.state.bindEach
 import ynab.BudgetSummary
 
-fun Container.budgetSelector(budgetSummaries: DataState<ObservableList<BudgetSummary>>, onBudgetSelect: (BudgetSummary) -> Unit) {
+fun Container.budgetSelector(
+  budgetSummaries: DataState<ObservableList<BudgetSummary>>,
+  onBudgetSelect: (BudgetSummary) -> Unit
+) {
   when (budgetSummaries) {
     is DataState.Unloaded, DataState.Loading -> {
       hPanel(spacing = 5) {
@@ -21,6 +24,7 @@ fun Container.budgetSelector(budgetSummaries: DataState<ObservableList<BudgetSum
         div("Loading budgets…")
       }
     }
+
     is DataState.Loaded -> {
       label("Select a budget:")
       hPanel(spacing = 5) {

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
@@ -10,85 +10,90 @@ import ynab.BudgetSummary
 import ynab.TransactionDetail
 
 class DataModel {
-    private val budgetsObservable = ObservableValue<DataState<ObservableList<BudgetSummary>>>(DataState.Unloaded)
-    private val selectedBudgetObservable = ObservableValue<BudgetSummary?>(null)
-    private val transactionsStoreObservable =
-      ObservableValue<DataState<MutableMap<String, TransactionDetail>>>(DataState.Unloaded)
-    private val displayedTransactionsObservable =
-      ObservableValue(observableListOf<TransactionDetail>())
+  private val budgetsObservable = ObservableValue<DataState<ObservableList<BudgetSummary>>>(DataState.Unloaded)
+  private val selectedBudgetObservable = ObservableValue<BudgetSummary?>(null)
+  private val transactionsStoreObservable =
+    ObservableValue<DataState<MutableMap<String, TransactionDetail>>>(DataState.Unloaded)
+  private val displayedTransactionsObservable =
+    ObservableValue(observableListOf<TransactionDetail>())
 
-    var budgets: DataState<ObservableList<BudgetSummary>>
-        get() = budgetsObservable.value
-        set(value) { budgetsObservable.value = value }
+  var budgets: DataState<ObservableList<BudgetSummary>>
+    get() = budgetsObservable.value
+    set(value) {
+      budgetsObservable.value = value
+    }
 
-    var selectedBudget: BudgetSummary?
-        get() = selectedBudgetObservable.value
-        set(value) { selectedBudgetObservable.value = value }
+  var selectedBudget: BudgetSummary?
+    get() = selectedBudgetObservable.value
+    set(value) {
+      selectedBudgetObservable.value = value
+    }
 
-    var transactionsStore: DataState<MutableMap<String, TransactionDetail>>
-        get() = transactionsStoreObservable.value
-        set(value) {
-            transactionsStoreObservable.value = value
-            updateDisplayedTxns()
+  var transactionsStore: DataState<MutableMap<String, TransactionDetail>>
+    get() = transactionsStoreObservable.value
+    set(value) {
+      transactionsStoreObservable.value = value
+      updateDisplayedTxns()
+    }
+
+  var displayedTransactions: ObservableList<TransactionDetail>
+    get() = displayedTransactionsObservable.value
+    set(value) {
+      displayedTransactionsObservable.value = value
+    }
+
+  fun updateDisplayedTxns() {
+    when (transactionsStore) {
+      is DataState.Unloaded -> {
+        displayedTransactions = observableListOf()
+      }
+
+      is DataState.Loading -> {
+        displayedTransactions = observableListOf()
+      }
+
+      is DataState.Loaded -> {
+        val txns = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data.values
+        // this could sort by anything… but for now, just sort by date
+        val sorted = txns.sortedBy { it.date }
+
+        // We don't want to trigger a re-render if the list is already loaded.
+        // Setting the value outright (vs replacing contents) triggers a higher-level re-render.
+        if (displayedTransactions is DataState.Loaded<*>) {
+          // The transaction store itself is not changing: it is still loaded.
+          // Clients observe the observable list of transactions.
+          val existingList = (displayedTransactions as DataState.Loaded<ObservableList<TransactionDetail>>).data
+          (existingList as ObservableListWrapper).replaceAll(sorted)
+        } else {
+          // If we aren't already loaded, just set the value.
+          // This will
+          displayedTransactions = observableListOf(*sorted.toTypedArray())
         }
-
-    var displayedTransactions: ObservableList<TransactionDetail>
-        get() = displayedTransactionsObservable.value
-        set(value) { displayedTransactionsObservable.value = value }
-
-    fun updateDisplayedTxns() {
-        when (transactionsStore) {
-            is DataState.Unloaded -> {
-                displayedTransactions = observableListOf()
-            }
-
-            is DataState.Loading -> {
-                displayedTransactions = observableListOf()
-            }
-
-            is DataState.Loaded -> {
-                val txns = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data.values
-                // this could sort by anything… but for now, just sort by date
-                val sorted = txns.sortedBy { it.date }
-
-                // We don't want to trigger a re-render if the list is already loaded.
-                // Setting the value outright (vs replacing contents) triggers a higher-level re-render.
-                if (displayedTransactions is DataState.Loaded<*>) {
-                    // The transaction store itself is not changing: it is still loaded.
-                    // Clients observe the observable list of transactions.
-                    val existingList = (displayedTransactions as DataState.Loaded<ObservableList<TransactionDetail>>).data
-                    (existingList as ObservableListWrapper).replaceAll(sorted)
-                }
-                else {
-                    // If we aren't already loaded, just set the value.
-                    // This will
-                    displayedTransactions = observableListOf(*sorted.toTypedArray())
-                }
-            }
-        }
+      }
     }
+  }
 
-    fun updateTransaction(original: TransactionDetail, updated: TransactionDetail) {
-        // replace the old object with the updated one
-        val storedTransactions = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data
-        storedTransactions[original.id] = updated
+  fun updateTransaction(original: TransactionDetail, updated: TransactionDetail) {
+    // replace the old object with the updated one
+    val storedTransactions = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data
+    storedTransactions[original.id] = updated
 
-        updateDisplayedTxns()
-    }
+    updateDisplayedTxns()
+  }
 
-    fun observeBudgets(): ObservableValue<DataState<ObservableList<BudgetSummary>>> {
-        return budgetsObservable
-    }
+  fun observeBudgets(): ObservableValue<DataState<ObservableList<BudgetSummary>>> {
+    return budgetsObservable
+  }
 
-    fun observeSelectedBudget(): ObservableValue<BudgetSummary?> {
-        return selectedBudgetObservable
-    }
+  fun observeSelectedBudget(): ObservableValue<BudgetSummary?> {
+    return selectedBudgetObservable
+  }
 
-    fun observeTransactionsStore(): ObservableValue<DataState<MutableMap<String, TransactionDetail>>> {
-        return transactionsStoreObservable
-    }
+  fun observeTransactionsStore(): ObservableValue<DataState<MutableMap<String, TransactionDetail>>> {
+    return transactionsStoreObservable
+  }
 
-    fun observeDisplayedTransactions(): ObservableValue<ObservableList<TransactionDetail>> {
-        return displayedTransactionsObservable
-    }
+  fun observeDisplayedTransactions(): ObservableValue<ObservableList<TransactionDetail>> {
+    return displayedTransactionsObservable
+  }
 }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
@@ -15,7 +15,7 @@ class DataModel {
     private val transactionsStoreObservable =
       ObservableValue<DataState<MutableMap<String, TransactionDetail>>>(DataState.Unloaded)
     private val displayedTransactionsObservable =
-      ObservableValue<DataState<ObservableList<TransactionDetail>>>(DataState.Unloaded)
+      ObservableValue(observableListOf<TransactionDetail>())
 
     var budgets: DataState<ObservableList<BudgetSummary>>
         get() = budgetsObservable.value
@@ -32,18 +32,18 @@ class DataModel {
             updateDisplayedTxns()
         }
 
-    var displayedTransactions: DataState<ObservableList<TransactionDetail>>
+    var displayedTransactions: ObservableList<TransactionDetail>
         get() = displayedTransactionsObservable.value
         set(value) { displayedTransactionsObservable.value = value }
 
     fun updateDisplayedTxns() {
         when (transactionsStore) {
             is DataState.Unloaded -> {
-                displayedTransactions = DataState.Unloaded
+                displayedTransactions = observableListOf()
             }
 
             is DataState.Loading -> {
-                displayedTransactions = DataState.Loading
+                displayedTransactions = observableListOf()
             }
 
             is DataState.Loaded -> {
@@ -62,7 +62,7 @@ class DataModel {
                 else {
                     // If we aren't already loaded, just set the value.
                     // This will
-                    displayedTransactions = DataState.Loaded(observableListOf(*sorted.toTypedArray()))
+                    displayedTransactions = observableListOf(*sorted.toTypedArray())
                 }
             }
         }
@@ -88,7 +88,7 @@ class DataModel {
         return transactionsStoreObservable
     }
 
-    fun observeDisplayedTransactions(): ObservableValue<DataState<ObservableList<TransactionDetail>>> {
+    fun observeDisplayedTransactions(): ObservableValue<ObservableList<TransactionDetail>> {
         return displayedTransactionsObservable
     }
 }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/DataModel.kt
@@ -1,0 +1,94 @@
+package com.dchaley.ynas
+
+import com.dchaley.ynas.util.DataState
+import com.dchaley.ynas.util.replaceAll
+import io.kvision.state.ObservableList
+import io.kvision.state.ObservableListWrapper
+import io.kvision.state.ObservableValue
+import io.kvision.state.observableListOf
+import ynab.BudgetSummary
+import ynab.TransactionDetail
+
+class DataModel {
+    private val budgetsObservable = ObservableValue<DataState<ObservableList<BudgetSummary>>>(DataState.Unloaded)
+    private val selectedBudgetObservable = ObservableValue<BudgetSummary?>(null)
+    private val transactionsStoreObservable =
+      ObservableValue<DataState<MutableMap<String, TransactionDetail>>>(DataState.Unloaded)
+    private val displayedTransactionsObservable =
+      ObservableValue<DataState<ObservableList<TransactionDetail>>>(DataState.Unloaded)
+
+    var budgets: DataState<ObservableList<BudgetSummary>>
+        get() = budgetsObservable.value
+        set(value) { budgetsObservable.value = value }
+
+    var selectedBudget: BudgetSummary?
+        get() = selectedBudgetObservable.value
+        set(value) { selectedBudgetObservable.value = value }
+
+    var transactionsStore: DataState<MutableMap<String, TransactionDetail>>
+        get() = transactionsStoreObservable.value
+        set(value) {
+            transactionsStoreObservable.value = value
+            updateDisplayedTxns()
+        }
+
+    var displayedTransactions: DataState<ObservableList<TransactionDetail>>
+        get() = displayedTransactionsObservable.value
+        set(value) { displayedTransactionsObservable.value = value }
+
+    fun updateDisplayedTxns() {
+        when (transactionsStore) {
+            is DataState.Unloaded -> {
+                displayedTransactions = DataState.Unloaded
+            }
+
+            is DataState.Loading -> {
+                displayedTransactions = DataState.Loading
+            }
+
+            is DataState.Loaded -> {
+                val txns = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data.values
+                // this could sort by anything… but for now, just sort by date
+                val sorted = txns.sortedBy { it.date }
+
+                // We don't want to trigger a re-render if the list is already loaded.
+                // Setting the value outright (vs replacing contents) triggers a higher-level re-render.
+                if (displayedTransactions is DataState.Loaded<*>) {
+                    // The transaction store itself is not changing: it is still loaded.
+                    // Clients observe the observable list of transactions.
+                    val existingList = (displayedTransactions as DataState.Loaded<ObservableList<TransactionDetail>>).data
+                    (existingList as ObservableListWrapper).replaceAll(sorted)
+                }
+                else {
+                    // If we aren't already loaded, just set the value.
+                    // This will
+                    displayedTransactions = DataState.Loaded(observableListOf(*sorted.toTypedArray()))
+                }
+            }
+        }
+    }
+
+    fun updateTransaction(original: TransactionDetail, updated: TransactionDetail) {
+        // replace the old object with the updated one
+        val storedTransactions = (transactionsStore as DataState.Loaded<MutableMap<String, TransactionDetail>>).data
+        storedTransactions[original.id] = updated
+
+        updateDisplayedTxns()
+    }
+
+    fun observeBudgets(): ObservableValue<DataState<ObservableList<BudgetSummary>>> {
+        return budgetsObservable
+    }
+
+    fun observeSelectedBudget(): ObservableValue<BudgetSummary?> {
+        return selectedBudgetObservable
+    }
+
+    fun observeTransactionsStore(): ObservableValue<DataState<MutableMap<String, TransactionDetail>>> {
+        return transactionsStoreObservable
+    }
+
+    fun observeDisplayedTransactions(): ObservableValue<DataState<ObservableList<TransactionDetail>>> {
+        return displayedTransactionsObservable
+    }
+}

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
@@ -1,13 +1,11 @@
 package com.dchaley.ynas
 
-import com.dchaley.ynas.util.DataState
 import com.dchaley.ynas.util.percentOf
 import com.dchaley.ynas.util.toUsd
 import io.kvision.core.*
 import io.kvision.html.*
 import io.kvision.panel.gridPanel
 import io.kvision.panel.hPanel
-import io.kvision.panel.vPanel
 import io.kvision.state.ObservableList
 import io.kvision.state.bindEach
 import io.kvision.table.*
@@ -41,99 +39,73 @@ fun equalTester(a: TransactionDetail, b: TransactionDetail): Boolean {
   return x
 }
 
-fun Container.transactionsList(transactionsState: DataState<ObservableList<TransactionDetail>>, onApprove: ((TransactionDetail) -> Unit)? = null) {
+fun Container.transactionsList(
+  transactions: ObservableList<TransactionDetail>,
+  onApprove: ((TransactionDetail) -> Unit)? = null
+) {
   val columns = listOf("Date", "Payee", "Category", "Memo", "Amount", "Actions")
   val tableStyling = setOf(TableType.STRIPED, TableType.HOVER)
-  val loadingStyling = tableStyling - TableType.HOVER
 
-  when (transactionsState) {
-    is DataState.Unloaded -> {
-      table(columns, loadingStyling, responsiveType = ResponsiveType.RESPONSIVE) {
-        row {
-          cell() {
-            setAttribute("colspan", columns.size.toString())
+  table(columns, tableStyling, responsiveType = ResponsiveType.RESPONSIVE)
+    .bindEach(transactions, equalizer = ::equalTester) { transaction ->
+      row {
+        cell {
+          verticalAlign = VerticalAlign.MIDDLE
+          whiteSpace = WhiteSpace.NOWRAP
+          content = transaction.date
+        }
+        cell(transaction.payee_name) {
+          verticalAlign = VerticalAlign.MIDDLE
+        }
+        if (transaction.category_name == "Split") {
+          cell {
+            verticalAlign = VerticalAlign.MIDDLE
+            small {
+              gridPanel(columnGap = 3) {
+                transaction.subtransactions.forEachIndexed { index, subTransaction ->
+                  val row = index + 1
+                  add(Div(subTransaction.category_name), 1, row)
+                  add(Div(subTransaction.amount.toUsd()), 2, row)
+                  add(Div(subTransaction.amount.percentOf(transaction.amount)), 3, row)
+                }
+              }
+            }
+          }
+        } else {
+          cell(transaction.category_name) {
+            verticalAlign = VerticalAlign.MIDDLE
+          }
+        }
+        cell {
+          verticalAlign = VerticalAlign.MIDDLE
+          if (transaction.memo.orEmpty().isNotEmpty()) {
+            link("", "#") {
+              icon("fas fa-note-sticky fa")
+              setAttribute("aria-label", "view memo")
+              enableTooltip(TooltipOptions(transaction.memo))
+            }
+          } else {
+            content = ""
+          }
+        }
+        cell(transaction.amount.toUsd()) {
+          verticalAlign = VerticalAlign.MIDDLE
+        }
+        cell {
+          verticalAlign = VerticalAlign.MIDDLE
+          hPanel(spacing = 2, justify = JustifyContent.SPACEBETWEEN) {
+            whiteSpace = WhiteSpace.NOWRAP
+            button("", "fas fa-pen-fancy fa-lg", style = ButtonStyle.SECONDARY) {
+              setAttribute("aria-label", "recategorize")
+            }
+            button("", "fas fa-code-branch fa-lg", style = ButtonStyle.SECONDARY) {
+              setAttribute("aria-label", "split")
+            }
+            button("", "fas fa-thumbs-up fa-lg", style = ButtonStyle.SECONDARY) {
+              setAttribute("aria-label", "approve")
+            }.onClick { onApprove?.invoke(transaction) }
           }
         }
       }
-
     }
-    is DataState.Loading -> {
-      table(columns, loadingStyling, responsiveType = ResponsiveType.RESPONSIVE) {
-        row {
-          cell() {
-            setAttribute("colspan", columns.size.toString())
-            vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
-              icon("fas fa-spinner fa-xl fa-spin")
-              h4("loading transactions…")
-            }
-          }
-        }
-      }
-    }
-    is DataState.Loaded -> {
-      val transactions = transactionsState.data
-      table(columns, tableStyling, responsiveType = ResponsiveType.RESPONSIVE)
-        .bindEach(transactions, equalizer = ::equalTester) { transaction ->
-          row {
-            cell {
-              verticalAlign = VerticalAlign.MIDDLE
-              whiteSpace = WhiteSpace.NOWRAP
-              content = transaction.date
-            }
-            cell(transaction.payee_name) {
-              verticalAlign = VerticalAlign.MIDDLE
-            }
-            if (transaction.category_name == "Split") {
-              cell {
-                verticalAlign = VerticalAlign.MIDDLE
-                small {
-                  gridPanel(columnGap = 3) {
-                    transaction.subtransactions.forEachIndexed { index, subTransaction ->
-                      val row = index + 1
-                      add(Div(subTransaction.category_name), 1, row)
-                      add(Div(subTransaction.amount.toUsd()), 2, row)
-                      add(Div(subTransaction.amount.percentOf(transaction.amount)), 3, row)
-                    }
-                  }
-                }
-              }
-            } else {
-              cell(transaction.category_name) {
-                verticalAlign = VerticalAlign.MIDDLE
-              }
-            }
-            cell {
-              verticalAlign = VerticalAlign.MIDDLE
-              if (transaction.memo.orEmpty().isNotEmpty()) {
-                  link("", "#") {
-                    icon("fas fa-note-sticky fa")
-                    setAttribute("aria-label", "view memo")
-                    enableTooltip(TooltipOptions(transaction.memo))
-                  }
-              } else {
-                content = ""
-              }
-            }
-            cell(transaction.amount.toUsd()) {
-              verticalAlign = VerticalAlign.MIDDLE
-            }
-            cell {
-              verticalAlign = VerticalAlign.MIDDLE
-              hPanel(spacing=2, justify = JustifyContent.SPACEBETWEEN) {
-                whiteSpace = WhiteSpace.NOWRAP
-                button("", "fas fa-pen-fancy fa-lg", style = ButtonStyle.SECONDARY) {
-                  setAttribute("aria-label", "recategorize")
-                }
-                button("", "fas fa-code-branch fa-lg", style = ButtonStyle.SECONDARY) {
-                  setAttribute("aria-label", "split")
-                }
-                button("", "fas fa-thumbs-up fa-lg", style = ButtonStyle.SECONDARY) {
-                  setAttribute("aria-label", "approve")
-                }.onClick { onApprove?.invoke(transaction) }
-              }
-            }
-          }
-      }
-    }
-  }
 }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
@@ -52,9 +52,6 @@ fun Container.transactionsList(transactionsState: DataState<ObservableList<Trans
         row {
           cell() {
             setAttribute("colspan", columns.size.toString())
-            vPanel(alignItems = AlignItems.CENTER, useWrappers = true) {
-              h4("no transactions loaded!")
-            }
           }
         }
       }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/ObservableListWrapper.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/ObservableListWrapper.kt
@@ -3,7 +3,7 @@ package com.dchaley.ynas.util
 import io.kvision.state.ObservableListWrapper
 
 // define an extension function on ObservableListWrapper that clears and adds all atomically
-fun <T> ObservableListWrapper<T>.replaceAll(newItems: List<T>) : Boolean {
+fun <T> ObservableListWrapper<T>.replaceAll(newItems: List<T>): Boolean {
   if (this.isEmpty() && newItems.isEmpty()) {
     return true
   }


### PR DESCRIPTION
The multiple layers of data state were confusing and unnecessary. If one day, the txn filtering takes so long that a loading state is meaningful, we can add it back.

This PR includes a bulk whitespace reformat in the last commit.

Fixes #7 