### PR TITLE
Parameterize transaction approval filter

### DIFF
--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -2,4 +2,4 @@ javaVersion=17
 #Plugins
 systemProp.kotlinVersion=1.9.20
 #Dependencies
-systemProp.kvisionVersion=7.2.0
+systemProp.kvisionVersion=7.5.1

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -58,10 +58,11 @@ class App : Application() {
       dataModel.updateTransaction(transactionDetail, copied)
     }
 
-    fun onSelectBudget(budget: BudgetSummary) {
+    fun onSelectBudget(budget: BudgetSummary, onlyUnapproved: Boolean) {
       dataModel.selectedBudget = budget
       dataModel.transactionsStore = DataState.Loading
-      ynab.transactions.getTransactions(budget.id, type = "unapproved").then { response ->
+      val txnType = if (onlyUnapproved) "unapproved" else ""
+      ynab.transactions.getTransactions(budget.id, type = txnType).then { response ->
         val pairs = response.data.transactions.map { it.id to it }.toTypedArray()
         dataModel.transactionsStore = DataState.Loaded(mutableMapOf(*pairs))
       }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -101,7 +101,9 @@ class App : Application() {
                   }
 
                   is DataState.Loading -> {
-                    icon("fas fa-spinner fa-xl fa-spin")
+                    p {
+                      icon("fas fa-spinner fa-xl fa-spin")
+                    }
                     h4("loading transactions…")
                   }
 

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
@@ -2,15 +2,17 @@ package com.dchaley.ynas
 
 import com.dchaley.ynas.util.DataState
 import io.kvision.core.Container
+import io.kvision.form.check.checkBox
 import io.kvision.html.*
 import io.kvision.panel.hPanel
+import io.kvision.panel.vPanel
 import io.kvision.state.ObservableList
 import io.kvision.state.bindEach
 import ynab.BudgetSummary
 
 fun Container.budgetSelector(
   budgetSummaries: DataState<ObservableList<BudgetSummary>>,
-  onBudgetSelect: (BudgetSummary) -> Unit
+  onBudgetSelect: (BudgetSummary, Boolean) -> Unit
 ) {
   when (budgetSummaries) {
     is DataState.Unloaded, DataState.Loading -> {
@@ -23,12 +25,15 @@ fun Container.budgetSelector(
     }
 
     is DataState.Loaded -> {
-      label("Select a budget:")
-      hPanel(spacing = 5) {
-      }.bindEach(budgetSummaries.data) { budget ->
-        button(text = budget.name) {
-          onClick {
-            onBudgetSelect(budget)
+      vPanel(spacing = 5) {
+        span("Select a budget:")
+        val c = checkBox(true, label = "Only show unapproved transactions")
+
+        hPanel(spacing = 5).bindEach(budgetSummaries.data) { budget ->
+          button(text = budget.name) {
+            onClick {
+              onBudgetSelect(budget, c.value)
+            }
           }
         }
       }

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/BudgetSelector.kt
@@ -2,10 +2,7 @@ package com.dchaley.ynas
 
 import com.dchaley.ynas.util.DataState
 import io.kvision.core.Container
-import io.kvision.html.button
-import io.kvision.html.div
-import io.kvision.html.icon
-import io.kvision.html.label
+import io.kvision.html.*
 import io.kvision.panel.hPanel
 import io.kvision.state.ObservableList
 import io.kvision.state.bindEach
@@ -18,7 +15,7 @@ fun Container.budgetSelector(
   when (budgetSummaries) {
     is DataState.Unloaded, DataState.Loading -> {
       hPanel(spacing = 5) {
-        div {
+        p {
           icon("fas fa-spinner fa-spin")
         }
         div("Loading budgets…")

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/Transactions.kt
@@ -80,7 +80,7 @@ fun Container.transactionsList(
           verticalAlign = VerticalAlign.MIDDLE
           if (transaction.memo.orEmpty().isNotEmpty()) {
             link("", "#") {
-              icon("fas fa-note-sticky fa")
+              icon = "fas fa-note-sticky fa"
               setAttribute("aria-label", "view memo")
               enableTooltip(TooltipOptions(transaction.memo))
             }


### PR DESCRIPTION
This provides a checkbox to control the `GetTransactions` API call filter type. If checked (default behavior), only unapproved transactions are fetched. If unchecked, all transactions are checked.

<img width="461" alt="Screenshot 2024-07-01 at 7 09 21 PM" src="https://github.com/dchaley/you-need-a-splitter/assets/352005/4f917141-c297-490d-8175-2af9766039a7">

Fixes #10 .

Along the way, upgrade KVision 7.2.0 → 7.5.1. And fix a very perplexing bug where icons can't be rendered in `div` (have to use `p`). Cost me like 4 hours 🤦🏻 