### PR TITLE
Implement default split category

### DIFF
--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/SplitModal.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/SplitModal.kt
@@ -28,8 +28,9 @@ data class SplitResult(
 fun splitModal(
   transaction: TransactionDetail,
   categories: Map<String, Category>,
+  defaultCategoryId: String? = null
 ): Dialog<SplitResult?> {
-  val splitCategoryId = ObservableValue<String?>(null)
+  val splitCategoryId = ObservableValue<String?>(defaultCategoryId)
 
   val txnAmount = transaction.amount.toInt()
   val category = categories[transaction.category_id]

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/CookieUtil.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/CookieUtil.kt
@@ -1,0 +1,40 @@
+package com.dchaley.ynas.util
+
+/**
+ * Utility functions for managing cookies using the document.cookie API.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+ */
+object CookieUtil {
+  private const val DEFAULT_CATEGORY_COOKIE_NAME = "defaultCategoryId"
+  private const val DEFAULT_PATH = "/"
+
+  /**
+   * Sets the default category ID in a cookie with a 1-year expiration date.
+   * @param categoryId The category ID to store
+   */
+  fun setDefaultCategoryId(categoryId: String) {
+    // Calculate expiration date (1 year from now)
+    val expirationDate = js("new Date()")
+    expirationDate.setFullYear(expirationDate.getFullYear() + 1)
+
+    // Set the cookie with document.cookie
+    val cookieString =
+      "$DEFAULT_CATEGORY_COOKIE_NAME=$categoryId; path=$DEFAULT_PATH; expires=${expirationDate.toUTCString()}"
+    js("document.cookie = cookieString")
+  }
+
+  /**
+   * Gets the default category ID from the cookie.
+   * @return The cookie value, or null if not found
+   */
+  fun getDefaultCategoryId(): String? {
+    // Get all cookies
+    val cookies = js("document.cookie").toString().split("; ")
+
+    // Find our cookie
+    val cookie = cookies.find { it.startsWith("$DEFAULT_CATEGORY_COOKIE_NAME=") }
+
+    // Extract and return the value
+    return cookie?.substringAfter("=")
+  }
+}

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/CookieUtil.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/util/CookieUtil.kt
@@ -1,5 +1,9 @@
 package com.dchaley.ynas.util
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+
 /**
  * Utility functions for managing cookies using the document.cookie API.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
@@ -9,32 +13,77 @@ object CookieUtil {
   private const val DEFAULT_PATH = "/"
 
   /**
-   * Sets the default category ID in a cookie with a 1-year expiration date.
-   * @param categoryId The category ID to store
+   * Encodes a string to Base64
+   * @param input The string to encode
+   * @return The Base64 encoded string
    */
-  fun setDefaultCategoryId(categoryId: String) {
+  private fun encodeToBase64(input: String): String {
+    return js("btoa(input)").toString()
+  }
+
+  /**
+   * Decodes a Base64 string
+   * @param input The Base64 encoded string
+   * @return The decoded string
+   */
+  private fun decodeFromBase64(input: String): String {
+    return js("atob(input)").toString()
+  }
+
+  /**
+   * Sets the default category ID map in a cookie with a 1-year expiration date.
+   * @param defaultCategoryMap The map of budget ID to default category ID
+   */
+  fun setDefaultCategoryId(defaultCategoryMap: Map<String, String>) {
     // Calculate expiration date (1 year from now)
     val expirationDate = js("new Date()")
     expirationDate.setFullYear(expirationDate.getFullYear() + 1)
 
+    // Convert map to JSON and encode to Base64
+    val jsonString = Json.encodeToString(defaultCategoryMap)
+    val encodedValue = encodeToBase64(jsonString)
+
     // Set the cookie with document.cookie
     val cookieString =
-      "$DEFAULT_CATEGORY_COOKIE_NAME=$categoryId; path=$DEFAULT_PATH; expires=${expirationDate.toUTCString()}"
+      "$DEFAULT_CATEGORY_COOKIE_NAME=$encodedValue; path=$DEFAULT_PATH; expires=${expirationDate.toUTCString()}"
     js("document.cookie = cookieString")
   }
 
   /**
-   * Gets the default category ID from the cookie.
-   * @return The cookie value, or null if not found
+   * Gets the default category ID map from the cookie.
+   * @return The map of budget ID to default category ID, or empty map if not found
    */
-  fun getDefaultCategoryId(): String? {
+  fun getDefaultCategoryId(): Map<String, String> {
     // Get all cookies
     val cookies = js("document.cookie").toString().split("; ")
 
     // Find our cookie
     val cookie = cookies.find { it.startsWith("$DEFAULT_CATEGORY_COOKIE_NAME=") }
 
-    // Extract and return the value
-    return cookie?.substringAfter("=")
+    // Extract the value
+    val encodedValue = cookie?.substringAfter("=")
+
+    // If no cookie found, return empty map
+    if (encodedValue == null) {
+      return emptyMap()
+    }
+
+    return try {
+      // Decode from Base64 and parse JSON
+      val jsonString = decodeFromBase64(encodedValue)
+      Json.decodeFromString<Map<String, String>>(jsonString)
+    } catch (e: Exception) {
+      console.error("Error decoding default category map: $e")
+      emptyMap()
+    }
+  }
+
+  /**
+   * For backward compatibility - gets the default category ID for a specific budget
+   * @param budgetId The budget ID
+   * @return The default category ID for the budget, or null if not found
+   */
+  fun getDefaultCategoryIdForBudget(budgetId: String): String? {
+    return getDefaultCategoryId()[budgetId]
   }
 }


### PR DESCRIPTION
Use cookies to store a map from budget id to default category id for that budget.

<img width="543" alt="Screenshot 2025-05-12 at 10 40 20 PM" src="https://github.com/user-attachments/assets/5f8a5249-41df-4b45-89f9-056076e243ed" />

The cookie stores a base64 encoding of a json object:

<img width="560" alt="Screenshot 2025-05-12 at 10 40 33 PM" src="https://github.com/user-attachments/assets/9c8f3706-91a0-4ff4-9e64-a745e39faad4" />

```
{"4a3f3fb5-a5b9-457a-9fb0-9a9f6821ed75":"afeedf68-1ae6-47c6-bb7b-7c82b438c0ae","ff265b4e-836d-4dbb-9363-d7d29b5e12eb":"e10de928-d2ee-4f5a-866b-72579ba9d5ef"}
```

Fixes #25 