### PR TITLE
Add default split percentage

### DIFF
--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/App.kt
@@ -4,6 +4,7 @@ import com.dchaley.ynas.util.DataState
 import io.kvision.*
 import io.kvision.core.AlignItems
 import io.kvision.form.select.select
+import io.kvision.form.text.text
 import io.kvision.html.*
 import io.kvision.panel.root
 import io.kvision.panel.vPanel
@@ -141,7 +142,8 @@ class App : Application() {
         val splitResult = splitModal(
           transactionDetail,
           categories,
-          dataModel.defaultCategoryId
+          dataModel.defaultCategoryId,
+          dataModel.defaultSplitPercentage,
         ).getResult()
 
         if (splitResult == null) {
@@ -168,8 +170,9 @@ class App : Application() {
       ynab.categories.getCategories(budget.id).then { response ->
         val pairs = response.data.category_groups.flatMap { it.categories.toList() }.map { it.id to it }.toTypedArray()
         dataModel.categoriesStore = DataState.Loaded(mutableMapOf(*pairs))
-        // Load default category from cookie after categories are loaded
+        // Load default category and split percentage from cookie after categories are loaded
         dataModel.loadDefaultCategoryFromCookie()
+        dataModel.loadDefaultSplitPercentageFromCookie()
       }
     }
 
@@ -254,6 +257,12 @@ class App : Application() {
                                 dataModel.displayedCategories.map { it.id to it.renderCategory() },
                         label = "Default Category"
                       ).bindTo(dataModel.observeDefaultCategoryId())
+
+                      // Add text input for default split percentage
+                      p("Enter a default split percentage:")
+                      text {
+                        placeholder = "e.g. 50"
+                      }.bindTo(dataModel.observeDefaultSplitPercentage())
                     }
 
                     categoriesTable(dataModel.displayedCategories)

--- a/kotlin/src/jsMain/kotlin/com/dchaley/ynas/SplitModal.kt
+++ b/kotlin/src/jsMain/kotlin/com/dchaley/ynas/SplitModal.kt
@@ -28,9 +28,10 @@ data class SplitResult(
 fun splitModal(
   transaction: TransactionDetail,
   categories: Map<String, Category>,
-  defaultCategoryId: String? = null
+  defaultCategoryId: String? = null,
+  initialSplitPercent: String? = null,
 ): Dialog<SplitResult?> {
-  val splitCategoryId = ObservableValue<String?>(defaultCategoryId)
+  val splitCategoryId = ObservableValue(defaultCategoryId)
 
   val txnAmount = transaction.amount.toInt()
   val category = categories[transaction.category_id]
@@ -115,6 +116,15 @@ fun splitModal(
     val newSplitAmount = txnAmount - newRemainingAmount
     setSplitAmount(newSplitAmount)
     setSplitPercent(newSplitAmount)
+  }
+
+  // Handle initialSplitPercent if provided and valid
+  if (!initialSplitPercent.isNullOrEmpty()) {
+    val percent = initialSplitPercent.toDoubleOrNull()
+    if (percent != null) {
+      splitPercentStr.value = initialSplitPercent
+      updateFromSplitPercent(initialSplitPercent)
+    }
   }
 
   return Dialog(


### PR DESCRIPTION
Adds a default split input field to the main app page. Fetch and save it in browser cookies. Pass the default split to the split modal, which uses it to set the split.

<img width="587" alt="Screenshot 2025-05-13 at 2 35 24 PM" src="https://github.com/user-attachments/assets/a114b1a3-cb9a-4bab-bd14-097f7033372d" />


There's currently odd behavior where setting a split percent like "15.5" can result in a number that results in a more precise percent being generated. I think it's due to how the values propagate through (setting the percent sets the value, which also sets the percentage based on that value…).

<img width="495" alt="Screenshot 2025-05-13 at 2 35 40 PM" src="https://github.com/user-attachments/assets/c75f8efa-5e10-418e-ac2e-9afcc51f7dfc" />


Another problem for another day… the net result is still correct, the default split still results in the expected split dollar amount.

Fixes #26 